### PR TITLE
削除処理が204を返すように修正

### DIFF
--- a/src/main/java/raisetech/crudsample/controller/Controller.java
+++ b/src/main/java/raisetech/crudsample/controller/Controller.java
@@ -57,13 +57,9 @@ public class Controller {
   }
 
   @DeleteMapping("/{id}")//idが存在しない場合は404を返す
-  public ResponseEntity<Map<String, String>> deleteMsg(@PathVariable int id) {
-    Message deletedMessage = msgService.findById(id);
+  public ResponseEntity deleteMsg(@PathVariable int id) {
     msgService.deleteMsg(id);
-    return ResponseEntity.ok(Map.of(
-            "id", String.valueOf(id),
-            "delete message", deletedMessage.getMsg(),
-            "message", "message successfully deleted"));
+    return ResponseEntity.noContent().build();
   }
 
   @ExceptionHandler(value = ResourceNotFoundException.class)

--- a/src/main/java/raisetech/crudsample/service/MsgServiceImpl.java
+++ b/src/main/java/raisetech/crudsample/service/MsgServiceImpl.java
@@ -47,7 +47,9 @@ public class MsgServiceImpl implements MsgService {
 
   @Override
   public void deleteMsg(int id) {
-    msgMapper.deleteMsg(id);
+    this.msgMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
+
+    this.msgMapper.deleteMsg(id);
 
   }
 


### PR DESCRIPTION
お世話になっております。
削除処理の変更をしました。変更点以下になります。
・Controllerでしていた例外処理をserviceクラスで行う
・ResponsEntityで削除内容と成功メッセージを返していたものを、noContent()で204を返す
更新処理で学んだ方法を踏襲しました。
POSTMANでの動作については、正常に機能しております。
■id54をgetで取得
<img width="632" alt="get" src="https://user-images.githubusercontent.com/107123973/216969949-a5f10096-c4c0-4088-8b3e-dba1dcb1ce6c.png">
■id54を削除実行
<img width="634" alt="delete" src="https://user-images.githubusercontent.com/107123973/216969971-c198a42d-c267-4b3f-a455-ef4f866b5077.png">
■id54の削除、Not Foundを確認
<img width="637" alt="check" src="https://user-images.githubusercontent.com/107123973/216969983-c99176d1-c103-4af5-b7b6-2a7394003b99.png">

レビューお願いいたします。
この課題をマージ後、登録処理の修正に入ります。
