### PR TITLE
serviceImplのcreateMsgでメッセージが登録され自動採番されたidがかえること

### DIFF
--- a/src/main/java/raisetech/crudsample/entity/Message.java
+++ b/src/main/java/raisetech/crudsample/entity/Message.java
@@ -24,6 +24,7 @@ public class Message {
     return false;
   }
 
+
   public Message() {
 
   }

--- a/src/main/java/raisetech/crudsample/entity/Message.java
+++ b/src/main/java/raisetech/crudsample/entity/Message.java
@@ -24,7 +24,6 @@ public class Message {
     return false;
   }
 
-
   public Message() {
 
   }

--- a/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
+++ b/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
@@ -56,10 +56,14 @@ class MsgServiceImplTest {
     verify(msgMapper).findById(999);
   }
 
-  //  @Test
-//  void createMsg() {
-//  }
-//
+  @Test
+  public void メッセージが登録され自動採番されたidを返すこと() {
+    doNothing().when(msgMapper).createMsg(new Message(1, "Hello"));
+
+    int newId = msgServiceImpl.createMsg("Hello");
+    assertThat(newId).isEqualTo(new Message(1, "Hello").getId());
+  }
+
 //  @Test
 //  void updateMsg() {
 //  }

--- a/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
+++ b/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
@@ -58,10 +58,10 @@ class MsgServiceImplTest {
 
   @Test
   public void メッセージが登録され自動採番されたidを返すこと() {
-    doNothing().when(msgMapper).createMsg(new Message(1, "Hello"));
+    doNothing().when(msgMapper).createMsg(new Message(0, "Hello"));
 
     int newId = msgServiceImpl.createMsg("Hello");
-    assertThat(newId).isEqualTo(new Message(1, "Hello").getId());
+    assertThat(newId).isEqualTo(new Message(0, "Hello").getId());
   }
 
 //  @Test


### PR DESCRIPTION
serviceImplクラスの単体テストに取り組んでおります。
現在、POSTのcreateMsgで「メッセージが登録され、自動採番されたidが返されること」をテストしているのですが、
失敗しており、解決法についてヒントを頂きたいです。

```
public void メッセージが登録され自動採番されたidを返すこと() {
    doNothing().when(msgMapper).createMsg(new Message(1, "Hello"));

    int newId = msgServiceImpl.createMsg("Hello");
    assertThat(newId).isEqualTo(new Message(1, "Hello").getId());
  }
```
エラー文
```
Strict stubbing argument mismatch. Please check:
 - this invocation of 'createMsg' method:
    msgMapper.createMsg(
    raisetech.crudsample.entity.Message@1440c311
);
    -> at raisetech.crudsample.service.MsgServiceImpl.createMsg(MsgServiceImpl.java:32)
 - has following stubbing(s) with different arguments:
    1. msgMapper.createMsg(
    raisetech.crudsample.entity.Message@5486887b
);
```

内容については、厳密なスタブの引数の不一致、というものであるらしく、
```
createMsgを呼び出すとこうなる
msgMapper.createMsg(
    raisetech.crudsample.entity.Message@783ec989);

MsgServiceImpl.createMsgには異なる引数で次のようなスタブがあります。
msgMapper.createMsg(
    raisetech.crudsample.entity.Message@1440c311);

```
上記のように引数が違うと怒られています。
■原因と疑ったこと
引数のMessageのハッシュ値が異なっていることから、newしたとき参照？の問題なのかとも考えました。
他のメソッドのテストの際、MessageクラスでEqualsメソッドのオーバーライドについて実装しておりますが、HashCodeメソッドの実装がないためかと思い、＠Dataアノテーションを付与してみたりもしましたが、それだけでは解決に至りませんでした。（＠Dataについては良く考慮して実装していないため一旦外してpushしています。調べたところ、EqualsとHashCodeは両方実装するか、どちらもしないかのどちらかにしないといけないとのことでしたので、本当は@Dataを付与する必要があるかなとは思っております。）

また、引数について、MapperのcreateMsgでは戻り値がなく、引数はMessageになっています。しかし、serviceImplのcreateMsgでは引数にStringのmsgをとり、Controllerにidを返す処理になっています。もしかしたらこの引数の違いを怒られているのではないか、とも考えました。しかし、やはりはっきりとした原因究明に至りませんでした。

解決のヒント等頂けるとありがたいです。
