### PR TITLE
deleteMsgのテストを実装

### DIFF
--- a/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
+++ b/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
@@ -87,7 +87,25 @@ class MsgServiceImplTest {
     verify(msgMapper, times(1)).findById(999);
   }
 
-//  @Test
-//  void deleteMsg() {
-//  }
+  @Test
+  public void 指定されたidが存在するときメッセージが削除されること() {
+    doReturn(Optional.of(new Message(1, "Hello"))).when(msgMapper).findById(1);
+
+    doNothing().when(msgMapper).deleteMsg(1);
+    try {
+      msgServiceImpl.deleteMsg(1);
+    } catch (ResourceNotFoundException e) {
+      fail(e.getMessage());
+    }
+    verify(msgMapper, times(1)).findById(1);
+    verify(msgMapper).deleteMsg(1);
+  }
+
+  @Test
+  public void 指定されたidが存在しない時例外がスローされること() {
+    doReturn(Optional.empty()).when(msgMapper).findById(999);
+
+    assertThrows(ResourceNotFoundException.class, () -> msgServiceImpl.deleteMsg(999));
+    verify(msgMapper, times(1)).findById(999);
+  }
 }

--- a/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
+++ b/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
@@ -94,7 +94,7 @@ class MsgServiceImplTest {
     doNothing().when(msgMapper).deleteMsg(1);
     try {
       msgServiceImpl.deleteMsg(1);
-    } catch (ResourceNotFoundException e) {
+    } catch (Exception e) {
       fail(e.getMessage());
     }
     verify(msgMapper, times(1)).findById(1);

--- a/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
+++ b/src/test/java/raisetech/crudsample/service/MsgServiceImplTest.java
@@ -98,7 +98,7 @@ class MsgServiceImplTest {
       fail(e.getMessage());
     }
     verify(msgMapper, times(1)).findById(1);
-    verify(msgMapper).deleteMsg(1);
+    verify(msgMapper, times(1)).deleteMsg(1);
   }
 
   @Test


### PR DESCRIPTION
お世話になります。
最終課題の単体テストを行っています。
serviceImplのDELETEのテスト、

- 指定されたidが存在する時メッセージが削除されること
- 存在しないidが指定されたとき例外がスローされること

のテストコードを実装しました。
テスト実行結果につきましては成功しております。
ご確認いただけますと幸いです。


