### PR TITLE
テスト改修

### DIFF
--- a/src/main/java/raisetech/crudsample/controller/Controller.java
+++ b/src/main/java/raisetech/crudsample/controller/Controller.java
@@ -1,11 +1,9 @@
 package raisetech.crudsample.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
-
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/raisetech/crudsample/controller/Controller.java
+++ b/src/main/java/raisetech/crudsample/controller/Controller.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 import raisetech.crudsample.entity.Message;
@@ -24,7 +23,6 @@ import raisetech.crudsample.service.MsgService;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/raisetech/crudsample/controller/Controller.java
+++ b/src/main/java/raisetech/crudsample/controller/Controller.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 import raisetech.crudsample.entity.Message;
@@ -21,6 +24,7 @@ import raisetech.crudsample.service.MsgService;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -79,6 +83,18 @@ public class Controller {
             "message", e.getMessage(),
             "path", request.getRequestURI());
     return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(value = MethodArgumentNotValidException.class)
+  @ResponseBody
+  public ResponseEntity<Map<String, Object>> handleMethodArgumentNotValidExceptionError(MethodArgumentNotValidException e, HttpServletRequest request) {
+    Map<String, String> body = Map.of(
+            "timestamp", ZonedDateTime.now().toString(),
+            "Status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+            "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            "message", "21文字以上のメッセージ、空文字、nullは許容されません。",
+            "path", request.getRequestURI());
+    return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
   }
 }
 

--- a/src/main/java/raisetech/crudsample/controller/Controller.java
+++ b/src/main/java/raisetech/crudsample/controller/Controller.java
@@ -1,10 +1,20 @@
 package raisetech.crudsample.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 import raisetech.crudsample.entity.Message;
 import raisetech.crudsample.form.MsgForm;

--- a/src/main/java/raisetech/crudsample/entity/Message.java
+++ b/src/main/java/raisetech/crudsample/entity/Message.java
@@ -1,7 +1,6 @@
 package raisetech.crudsample.entity;
 
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/raisetech/crudsample/form/MsgForm.java
+++ b/src/main/java/raisetech/crudsample/form/MsgForm.java
@@ -1,7 +1,6 @@
 package raisetech.crudsample.form;
 
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/raisetech/crudsample/repository/MsgMapper.java
+++ b/src/main/java/raisetech/crudsample/repository/MsgMapper.java
@@ -1,6 +1,12 @@
 package raisetech.crudsample.repository;
 
-import org.apache.ibatis.annotations.*;
+
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import raisetech.crudsample.entity.Message;
 
 import java.util.List;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,8 @@ spring.datasource.url=jdbc:mysql://localhost:3307/messages_db
 spring.datasource.username=vatic
 spring.datasource.password=francois0413
 mybatis.configuration.map-underscore-to-camel-case=true
+server.error.include-message=never
+server.error.include-binding-errors=never
+server.error.include-stacktrace=never
+server.error.include-exception=false
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,8 +2,3 @@ spring.datasource.url=jdbc:mysql://localhost:3307/messages_db
 spring.datasource.username=vatic
 spring.datasource.password=francois0413
 mybatis.configuration.map-underscore-to-camel-case=true
-server.error.include-message=never
-server.error.include-binding-errors=never
-server.error.include-stacktrace=never
-server.error.include-exception=false
-

--- a/src/test/java/raisetech/crudsample/integrationtest/MessageRestApiIntegrationTest.java
+++ b/src/test/java/raisetech/crudsample/integrationtest/MessageRestApiIntegrationTest.java
@@ -31,7 +31,7 @@ public class MessageRestApiIntegrationTest {
   @Test
   @DataSet(value = "datasets/it_全てのメッセージが取得できること/message.yml")
   @Transactional
-  void 全てのメッセージが取得できること() throws Exception {
+  void it_全てのメッセージが取得できること() throws Exception {
     String responce = mockMvc.perform(MockMvcRequestBuilders.get("/msg"))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
@@ -58,7 +58,7 @@ public class MessageRestApiIntegrationTest {
   @Test
   @DataSet(value = "datasets/it_メッセージが存在しないとき空の配列と200が返されること/message.yml")
   @Transactional
-  void メッセージが存在しないとき空の空の配列と200が返されること() throws Exception {
+  void it_メッセージが存在しないとき空の空の配列と200が返されること() throws Exception {
     String responce = mockMvc.perform(MockMvcRequestBuilders.get("/msg"))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
@@ -71,7 +71,7 @@ public class MessageRestApiIntegrationTest {
   @Test
   @DataSet(value = "datasets/it_指定されたidのメッセージが存在するときメッセージが返されること/message.yml")
   @Transactional
-  void 指定されたidのメッセージが存在するときメッセージが返されること() throws Exception {
+  void it_指定されたidのメッセージが存在するときメッセージが返されること() throws Exception {
     String responce = mockMvc.perform(MockMvcRequestBuilders.get("/msg/{id}", 3))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);

--- a/src/test/java/raisetech/crudsample/integrationtest/MessageRestApiIntegrationTest.java
+++ b/src/test/java/raisetech/crudsample/integrationtest/MessageRestApiIntegrationTest.java
@@ -134,6 +134,84 @@ public class MessageRestApiIntegrationTest {
   }
 
   @Test
+  @Transactional
+  void it_21文字以上のメッセージがリクエストされたとき登録せずエラーメッセージが返されること() throws Exception {
+    String response = mockMvc.perform(MockMvcRequestBuilders.post("/msg")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content("""
+                            {
+                                "msg":"111111111111111111111111111111111111111"
+                            }
+                            """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+                    {
+                        "message": "21文字以上のメッセージ、空文字、nullは許容されません。",
+                        "timestamp": "2023-04-07T16:35:09.423044300+09:00[Asia/Tokyo]",
+                        "error": "Bad Request",
+                        "Status": "400",
+                        "path": "/msg"
+                    }
+                    """, response,
+            new CustomComparator(JSONCompareMode.LENIENT,
+                    new Customization("timestamp", (o1, o2) -> true)));
+  }
+
+  @Test
+  @Transactional
+  void it_空文字のメッセージがリクエストされたとき登録せずエラーメッセージが返されること() throws Exception {
+    String response = mockMvc.perform(MockMvcRequestBuilders.post("/msg")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content("""
+                            {
+                                "msg":""
+                            }
+                            """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+                    {
+                        "message": "21文字以上のメッセージ、空文字、nullは許容されません。",
+                        "timestamp": "2023-04-07T16:35:09.423044300+09:00[Asia/Tokyo]",
+                        "error": "Bad Request",
+                        "Status": "400",
+                        "path": "/msg"
+                    }
+                    """, response,
+            new CustomComparator(JSONCompareMode.LENIENT,
+                    new Customization("timestamp", (o1, o2) -> true)));
+  }
+
+  @Test
+  @Transactional
+  void it_nullがリクエストされたとき登録せずエラーメッセージが返されること() throws Exception {
+    String response = mockMvc.perform(MockMvcRequestBuilders.post("/msg")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content("""
+                            {
+                                "msg":null
+                            }
+                            """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+                    {
+                        "message": "21文字以上のメッセージ、空文字、nullは許容されません。",
+                        "timestamp": "2023-04-07T16:35:09.423044300+09:00[Asia/Tokyo]",
+                        "error": "Bad Request",
+                        "Status": "400",
+                        "path": "/msg"
+                    }
+                    """, response,
+            new CustomComparator(JSONCompareMode.LENIENT,
+                    new Customization("timestamp", (o1, o2) -> true)));
+  }
+
+  @Test
   @DataSet(value = "datasets/it_指定されたidのメッセージが存在するときメッセージが更新されること/message.yml")
   @Transactional
   void it_指定されたidのメッセージが存在するときメッセージが更新されること() throws Exception {
@@ -160,6 +238,7 @@ public class MessageRestApiIntegrationTest {
                             """))
             .andExpect(MockMvcResultMatchers.status().isNotFound())
             .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
     JSONAssert.assertEquals("""
                               {
                                   "error": "Not Found",
@@ -172,6 +251,85 @@ public class MessageRestApiIntegrationTest {
             new CustomComparator(JSONCompareMode.LENIENT,
                     new Customization("timestamp", (o1, o2) -> true)));
   }
+
+  @Test
+  @Transactional
+  void it_21文字以上のメッセージがリクエストされたとき更新せずエラーメッセージが返されること() throws Exception {
+    String response = mockMvc.perform(MockMvcRequestBuilders.patch("/msg/{id}", 1)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content("""
+                            {
+                                "msg":"111111111111111111111111111111111111111"
+                            }
+                            """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+                                {
+                                    "error": "Bad Request",
+                                    "timestamp": "2023-04-07T20:00:54.970235+09:00[Asia/Tokyo]",
+                                    "message": "21文字以上のメッセージ、空文字、nullは許容されません。",
+                                    "path": "/msg/1",
+                                    "Status": "400"
+                                }
+                    """, response,
+            new CustomComparator(JSONCompareMode.LENIENT,
+                    new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  @Test
+  @Transactional
+  void nullがリクエストされたとき更新せずエラーメッセージが返されること() throws Exception {
+    String response = mockMvc.perform(MockMvcRequestBuilders.patch("/msg/{id}", 1)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content("""
+                            {
+                                "msg":null
+                            }
+                            """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+                                {
+                                    "error": "Bad Request",
+                                    "timestamp": "2023-04-07T20:00:54.970235+09:00[Asia/Tokyo]",
+                                    "message": "21文字以上のメッセージ、空文字、nullは許容されません。",
+                                    "path": "/msg/1",
+                                    "Status": "400"
+                                }
+                    """, response,
+            new CustomComparator(JSONCompareMode.LENIENT,
+                    new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
+  @Test
+  @Transactional
+  void it_空文字がリクエストされたとき更新せずエラーメッセージが返されること() throws Exception {
+    String response = mockMvc.perform(MockMvcRequestBuilders.patch("/msg/{id}", 1)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content("""
+                            {
+                                "msg":""
+                            }
+                            """))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    JSONAssert.assertEquals("""
+                                {
+                                    "error": "Bad Request",
+                                    "timestamp": "2023-04-07T20:00:54.970235+09:00[Asia/Tokyo]",
+                                    "message": "21文字以上のメッセージ、空文字、nullは許容されません。",
+                                    "path": "/msg/1",
+                                    "Status": "400"
+                                }
+                    """, response,
+            new CustomComparator(JSONCompareMode.LENIENT,
+                    new Customization("timestamp", ((o1, o2) -> true))));
+  }
+
 
   @Test
   @DataSet("datasets/it_指定されたidのメッセージが存在するとき削除されること/message.yml")

--- a/src/test/resources/datasets/it_全てのメッセージが取得できること/message.yml
+++ b/src/test/resources/datasets/it_全てのメッセージが取得できること/message.yml
@@ -3,5 +3,5 @@ message:
     msg: "Hello"
   - id: 2
     msg: "Bye"
-  - id:
+  - id: 3
     msg: "Hi"


### PR DESCRIPTION
お世話になっております。
最終課題について、仕様の確認を行っております。
ControllerクラスのPOST及びPATCHのバリデーションエラーの処理、テストの実装を行いました。
■バリデーションエラーの処理
・ControllerクラスのPOST、PATCHのリクエストボディのバリデーションで発生するMethodArgumentNotValidExceptionについてハンドリングする。
・21文字以上のメッセージ、空文字、nullのリクエストについて400（Bad_Request）と所定のエラーメッセージを返す。
メッセージ以下：
```
 "message": "21文字以上のメッセージ、空文字、nullは許容されません。",
    "path": "/msg(/{id})",
    "Status": "400",
    "error": "Bad Request",
    "timestamp": "2023-04-08T22:03:05.434855600+09:00[Asia/Tokyo]"
```
■結合テストの実装
・POST
①21文字以上のメッセージがリクエストされたとき登録されずエラーメッセージが返されること
②空文字がリクエストされたとき登録されずエラーメッセージが返されること
③nullがリクエストされたとき登録されずエラーメッセージが返されること
・PATCH
①21文字以上のメッセージがリクエストされたとき更新されずエラーメッセージが返されること
②空文字がリクエストされたとき更新されずエラーメッセージが返されること
③nullがリクエストされたとき更新されずエラーメッセージが返されること
■テスト結果
テストについては、追加したテストの影響等なくすべてのクラスのテストが成功している。
①MessageRestApiIntegrationTestクラス
追加したテスト含め、結合テストのすべてが成功。
<img width="449" alt="スクリーンショット 2023-04-08 222336" src="https://user-images.githubusercontent.com/107123973/230723594-65e862fa-0035-429d-8026-14bb2b571a8c.png">
②MsgServiceImplTestクラス
全て成功。
<img width="454" alt="スクリーンショット 2023-04-08 221053" src="https://user-images.githubusercontent.com/107123973/230723048-ad126cf0-9c7d-4c86-a3a4-fe5e0a61a0a3.png">
③MsgMapperTestクラス
全て成功。
<img width="452" alt="スクリーンショット 2023-04-08 221258" src="https://user-images.githubusercontent.com/107123973/230723110-a137093d-abc2-41dc-b011-3cc022d098f9.png">

ご確認いただけますと幸いです。よろしくお願いいたします。




